### PR TITLE
выполнено ПЗ

### DIFF
--- a/RouteTracker/App/AppDelegate.swift
+++ b/RouteTracker/App/AppDelegate.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import GoogleMaps
+import UserNotifications
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -17,6 +18,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
+        let center = UNUserNotificationCenter.current()
+        center.requestAuthorization(options: [.alert, .badge, .sound]) { granted, erro in
+            guard granted else {
+                print("Разрешение не получено")
+                return
+            }
+        }
+        
         GMSServices.provideAPIKey("AIzaSyBhBKNoqxDUL3PjU_8riBL5lITFQqqTV8s")
         
         window = UIWindow()
@@ -26,6 +35,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         coordinator?.start()
         
         return true
+    }
+    
+    func applicationDidEnterBackground(_ application: UIApplication) {
+        self.sendNotificationRequest(
+            content: self.makeNotificationContent(),
+            trigger: self.makeIntervalNotificationTrigger()
+        )
     }
         
     func applicationWillEnterForeground(_ application: UIApplication) {
@@ -45,20 +61,31 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         self.visualEffectView.removeFromSuperview()
     }
     
-    // MARK: UISceneSession Lifecycle
-
-    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-        // Called when a new scene session is being created.
-        // Use this method to select a configuration to create the new scene with.
-        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    func sendNotificationRequest(content: UNNotificationContent, trigger: UNNotificationTrigger) {
+        let request = UNNotificationRequest(
+            identifier: "alarm",
+            content: content,
+            trigger: trigger
+        )
+        
+        let center = UNUserNotificationCenter.current()
+        center.add(request) { error in
+            if let error = error {
+                print(error.localizedDescription)
+            }
+        }
     }
-
-    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
-        // Called when the user discards a scene session.
-        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
-        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    
+    func makeNotificationContent() -> UNNotificationContent {
+        let content = UNMutableNotificationContent()
+        content.title = "Ты куда пропал?"
+        content.subtitle = "Вернись!"
+        content.body = "Я ВСЕ ПРОЩУ!"
+        return content
     }
-
-
+    
+    func makeIntervalNotificationTrigger() -> UNNotificationTrigger {
+        return UNTimeIntervalNotificationTrigger (timeInterval: 20, repeats: false)
+    }
 }
 

--- a/RouteTracker/App/SceneDelegate.swift
+++ b/RouteTracker/App/SceneDelegate.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import GoogleMaps
+import UserNotifications
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
@@ -28,13 +29,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         coordinator?.start()
         
         return
-    }
-
-    func sceneDidDisconnect(_ scene: UIScene) {
-        // Called as the scene is being released by the system.
-        // This occurs shortly after the scene enters the background, or when its session is discarded.
-        // Release any resources associated with this scene that can be re-created the next time the scene connects.
-        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
     }
 
     func sceneDidBecomeActive(_ scene: UIScene) {
@@ -64,8 +58,38 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Called as the scene transitions from the foreground to the background.
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.
+        self.sendNotificationRequest(
+            content: self.makeNotificationContent(),
+            trigger: self.makeIntervalNotificationTrigger()
+        )
     }
 
+    func sendNotificationRequest(content: UNNotificationContent, trigger: UNNotificationTrigger) {
+        let request = UNNotificationRequest(
+            identifier: "alarm",
+            content: content,
+            trigger: trigger
+        )
+        
+        let center = UNUserNotificationCenter.current()
+        center.add(request) { error in
+            if let error = error {
+                print(error.localizedDescription)
+            }
+        }
+    }
+    
+    func makeNotificationContent() -> UNNotificationContent {
+        let content = UNMutableNotificationContent()
+        content.title = "Ты куда пропал?"
+        content.subtitle = "Вернись!"
+        content.body = "Я ВСЕ ПРОЩУ!"
+        return content
+    }
+    
+    func makeIntervalNotificationTrigger() -> UNNotificationTrigger {
+        return UNTimeIntervalNotificationTrigger (timeInterval: 20, repeats: false)
+    }
 
 }
 


### PR DESCRIPTION
1. При закрытии или сворачивании приложения регистрировать отправку пуш-уведомления.
2. Уведомление должно быть показано через 30 минут.
3. Показывать можно произвольный текст с призывом вернуться к использованию приложения.